### PR TITLE
Correction on file syntax

### DIFF
--- a/v2/Openpay/Openpay/es.lproj/Localizable.strings
+++ b/v2/Openpay/Openpay/es.lproj/Localizable.strings
@@ -7,8 +7,8 @@
 */
 "error.json" = "La respuesta de Openpay no pudo convertirse a JSON.";
 "error.session" = "El sessionID no pudo generarse, por favor intente de nuevo";
-"error.request" = "Respuesta con error";;
-"debug.request" = "Enviando petición a"
+"error.request" = "Respuesta con error";
+"debug.request" = "Enviando petición a";
 "debug.responseok" = "Ok! Se recibió una respuesta correcta";
 "button.cancel" = "Cancelar";
 "button.continue" = "Continuar";


### PR DESCRIPTION
A missed token (";") on line 11 cause a Fatal Error when Spanish (Latin American) idiom is used.