### PR TITLE
Unsubsrcibe NotificationCenter observers

### DIFF
--- a/v2/Openpay/Openpay/Openpay.swift
+++ b/v2/Openpay/Openpay/Openpay.swift
@@ -11,7 +11,7 @@ import UIKit
 import WebKit
 
 public class Openpay {
-    
+
     private static let API_URL_SANDBOX = "https://sandbox-api.openpay.mx"
     private static let API_URL_PRODUCTION = "https://api.openpay.mx"
     private static let API_VERSION = "1.1"
@@ -99,11 +99,11 @@ public class Openpay {
     }
     
     public func getTokenWithId(tokenId: String,
-                               successFunction: @escaping (_ responseParams: OPToken) -> Void,
-                               failureFunction: @escaping (_ error: NSError) -> Void ) {
+                        successFunction: @escaping (_ responseParams: OPToken) -> Void,
+                        failureFunction: @escaping (_ error: NSError) -> Void ) {
         
         sendFunction(method: String(format: "%@/%@",Openpay.OP_MODULE_TOKENS,tokenId), data: nil, httpMethod: Openpay.OP_HTTP_METHOD_GET, successFunction: successFunction, failureFunction: failureFunction)
-        
+
     }
     
     public func createDeviceSessionId(successFunction: @escaping (_ sessionId: String) -> Void,
@@ -137,10 +137,10 @@ public class Openpay {
     }
     
     private func sendFunction( method: String,
-                               data: Dictionary<String, Any>!,
-                               httpMethod: String,
-                               successFunction: @escaping (_ responseParams: OPToken) -> Void,
-                               failureFunction: @escaping (_ error: NSError) -> Void) {
+                       data: Dictionary<String, Any>!,
+                       httpMethod: String,
+                       successFunction: @escaping (_ responseParams: OPToken) -> Void,
+                       failureFunction: @escaping (_ error: NSError) -> Void) {
         
         var operationError: NSError!
         let urlPath: String = String(format: "%@/v1/%@/%@", ( isProductionMode == true ? Openpay.API_URL_PRODUCTION : Openpay.API_URL_SANDBOX ), self.merchantId, method)
@@ -199,11 +199,11 @@ public class Openpay {
                 failureFunction(operationError!)
             }
             
-            
+
         }
         
         task.resume()
-        
+
     }
     
     
@@ -226,18 +226,18 @@ public class Openpay {
         } catch {
             print("dictionaryFromJSONData Error: \(outError)")
         }
-        
+
         return jsonDictionary;
     }
-    
+
     
     
     
     public func loadCardForm(in viewController: UIViewController,
-                             successFunction: @escaping () -> Void,
-                             failureFunction: @escaping (_ error: NSError) -> Void,
-                             formTitle: String
-        ) {
+                                successFunction: @escaping () -> Void,
+                                failureFunction: @escaping (_ error: NSError) -> Void,
+                                formTitle: String
+                            ) {
         print("Display CardForm...")
         processCard = OPCard()
         cardView = CardView.instanceFromNib()
@@ -256,7 +256,7 @@ public class Openpay {
         
         let touch = UITapGestureRecognizer(target:self, action: #selector(touchView) )
         cardView.addGestureRecognizer(touch)
-        
+      
         // set actions for each button
         if let topItem = nav.navigationBar.topItem {
             topItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("button.cancel", bundle: Bundle(for: Openpay.self), comment: "Cancel"),
@@ -316,7 +316,7 @@ public class Openpay {
         if let inView = self.cardViewController.view.viewWithTag(indexTag.inview.rawValue) as? CardView {
             self.inview = inView
         }
-        
+
     }
     
     
@@ -330,13 +330,16 @@ public class Openpay {
     }
     
     private func textFieldShouldReturn(textField: UITextField) {
-        let nextTage = textField.tag+1
+        let nextTage=textField.tag+1;
         if nextTage == indexTag.picker.rawValue {
             showDatePicker()
-        } else if let nextResponder = self.cardViewController.view.viewWithTag(nextTage) {
-            nextResponder.becomeFirstResponder()
-        } else {
-            textField.resignFirstResponder()
+        }else {
+            let nextResponder=self.cardViewController.view.viewWithTag(nextTage) as UIResponder!
+            if (nextResponder != nil){
+                nextResponder?.becomeFirstResponder()
+            } else {
+                textField.resignFirstResponder()
+            }
         }
     }
     
@@ -354,7 +357,7 @@ public class Openpay {
     }
     
     private func validateCharacters(textFieldToChange: UITextField) {
-        for chr in (textFieldToChange.text)! {
+        for chr in (textFieldToChange.text?.characters)! {
             if (!(chr >= "a" && chr <= "z") && !(chr >= "A" && chr <= "Z") && !(chr >= " " && chr <= " ") ) {
                 textFieldToChange.deleteBackward()
             }
@@ -437,11 +440,11 @@ public class Openpay {
             segments = [4,8,12,16]
         }
         
-        var ci: Int = 0
-        var cp: Int = 0
-        for i in cleanNumber {
+        var ci: Int = 0;
+        var cp: Int = 0;
+        for i in cleanNumber.characters {
             if( segments[0] != 0 && cp == segments[ci] ) {
-                outNumber.append(separator)
+                outNumber.characters.append(separator)
                 if(segments.count > 1) {
                     if(ci < segments.count) {
                         ci += 1
@@ -450,7 +453,7 @@ public class Openpay {
                     }
                 }
             }
-            outNumber.append(i)
+            outNumber.characters.append(i)
             cp += 1
         }
         
@@ -464,11 +467,11 @@ public class Openpay {
         let min = 5
         validateCharacters(textFieldToChange: textField)
         processCard.holderName = textField.text!
-        holderValid = ((textField.text?.count)! > min && (textField.text?.count)! <= max)
+        holderValid = ((textField.text?.characters.count)! > min && (textField.text?.characters.count)! <= max)
         textField.textColor = holderValid ? UIColor.black : UIColor.red
-        if textField.text?.count == max && holderValid {
+        if textField.text?.characters.count == max && holderValid {
             textFieldShouldReturn(textField: textField)
-        } else if (textField.text?.count)! > max {
+        } else if (textField.text?.characters.count)! > max {
             textField.deleteBackward()
         }
         checkButtonCard()
@@ -480,7 +483,7 @@ public class Openpay {
         if processCard.numberValid {
             textFieldShouldReturn(textField: textField)
         }
-        if (textField.text?.count)! > max {
+        if (textField.text?.characters.count)! > max {
             textField.deleteBackward()
         }
         let formattedNumber = formatCardNumber(cardNumber: textField.text!, type: processCard.type)
@@ -495,7 +498,7 @@ public class Openpay {
         if cvvValid {
             textField.superview?.endEditing(true)
         }
-        if (textField.text?.count)! > max {
+        if (textField.text?.characters.count)! > max {
             textField.deleteBackward()
         }
         checkButtonCard()
@@ -516,9 +519,10 @@ public class Openpay {
                 processCard.expirationYear = String(format: "%02d", (year.value-2000))
                 dateField.setTitle(String(format: "%02d / %04d", month.value, year.value), for: UIControlState.normal)
                 checkButtonCard()
-                let nextTag = picker.tag+1
-                if let nextResponder = self.cardViewController.view.viewWithTag(nextTag) {
-                    nextResponder.becomeFirstResponder()
+                let nextTag = picker.tag+1;
+                let nextResponder = self.cardViewController.view.viewWithTag(nextTag) as UIResponder!
+                if (nextResponder != nil) {
+                    nextResponder?.becomeFirstResponder()
                 } else {
                     picker.resignFirstResponder()
                 }
@@ -538,10 +542,10 @@ public class Openpay {
         if let cvvField = self.cardViewController.view.viewWithTag(indexTag.cvv.rawValue) as? SecureUITextField {
             cvvField.textColor = (processCard.securityCodeCheck == OPCard.OPCardSecurityCodeCheck.OPCardSecurityCodeCheckPassed) ? UIColor.black : UIColor.red
         }
-        
+
         let enabled = processCard.valid &&
-            (processCard.securityCodeCheck == OPCard.OPCardSecurityCodeCheck.OPCardSecurityCodeCheckPassed) &&
-        holderValid
+                      (processCard.securityCodeCheck == OPCard.OPCardSecurityCodeCheck.OPCardSecurityCodeCheckPassed) &&
+                      holderValid
         
         if let topItem = cardViewController.navigationController?.navigationBar.topItem {
             topItem.rightBarButtonItem?.isEnabled = enabled

--- a/v2/Openpay/Openpay/Openpay.swift
+++ b/v2/Openpay/Openpay/Openpay.swift
@@ -11,7 +11,7 @@ import UIKit
 import WebKit
 
 public class Openpay {
-
+    
     private static let API_URL_SANDBOX = "https://sandbox-api.openpay.mx"
     private static let API_URL_PRODUCTION = "https://api.openpay.mx"
     private static let API_VERSION = "1.1"
@@ -99,11 +99,11 @@ public class Openpay {
     }
     
     public func getTokenWithId(tokenId: String,
-                        successFunction: @escaping (_ responseParams: OPToken) -> Void,
-                        failureFunction: @escaping (_ error: NSError) -> Void ) {
+                               successFunction: @escaping (_ responseParams: OPToken) -> Void,
+                               failureFunction: @escaping (_ error: NSError) -> Void ) {
         
         sendFunction(method: String(format: "%@/%@",Openpay.OP_MODULE_TOKENS,tokenId), data: nil, httpMethod: Openpay.OP_HTTP_METHOD_GET, successFunction: successFunction, failureFunction: failureFunction)
-
+        
     }
     
     public func createDeviceSessionId(successFunction: @escaping (_ sessionId: String) -> Void,
@@ -137,10 +137,10 @@ public class Openpay {
     }
     
     private func sendFunction( method: String,
-                       data: Dictionary<String, Any>!,
-                       httpMethod: String,
-                       successFunction: @escaping (_ responseParams: OPToken) -> Void,
-                       failureFunction: @escaping (_ error: NSError) -> Void) {
+                               data: Dictionary<String, Any>!,
+                               httpMethod: String,
+                               successFunction: @escaping (_ responseParams: OPToken) -> Void,
+                               failureFunction: @escaping (_ error: NSError) -> Void) {
         
         var operationError: NSError!
         let urlPath: String = String(format: "%@/v1/%@/%@", ( isProductionMode == true ? Openpay.API_URL_PRODUCTION : Openpay.API_URL_SANDBOX ), self.merchantId, method)
@@ -199,11 +199,11 @@ public class Openpay {
                 failureFunction(operationError!)
             }
             
-
+            
         }
         
         task.resume()
-
+        
     }
     
     
@@ -226,18 +226,18 @@ public class Openpay {
         } catch {
             print("dictionaryFromJSONData Error: \(outError)")
         }
-
+        
         return jsonDictionary;
     }
-
+    
     
     
     
     public func loadCardForm(in viewController: UIViewController,
-                                successFunction: @escaping () -> Void,
-                                failureFunction: @escaping (_ error: NSError) -> Void,
-                                formTitle: String
-                            ) {
+                             successFunction: @escaping () -> Void,
+                             failureFunction: @escaping (_ error: NSError) -> Void,
+                             formTitle: String
+        ) {
         print("Display CardForm...")
         processCard = OPCard()
         cardView = CardView.instanceFromNib()
@@ -256,7 +256,7 @@ public class Openpay {
         
         let touch = UITapGestureRecognizer(target:self, action: #selector(touchView) )
         cardView.addGestureRecognizer(touch)
-      
+        
         // set actions for each button
         if let topItem = nav.navigationBar.topItem {
             topItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("button.cancel", bundle: Bundle(for: Openpay.self), comment: "Cancel"),
@@ -316,7 +316,7 @@ public class Openpay {
         if let inView = self.cardViewController.view.viewWithTag(indexTag.inview.rawValue) as? CardView {
             self.inview = inView
         }
-
+        
     }
     
     
@@ -330,16 +330,13 @@ public class Openpay {
     }
     
     private func textFieldShouldReturn(textField: UITextField) {
-        let nextTage=textField.tag+1;
+        let nextTage = textField.tag+1
         if nextTage == indexTag.picker.rawValue {
             showDatePicker()
-        }else {
-            let nextResponder=self.cardViewController.view.viewWithTag(nextTage) as UIResponder!
-            if (nextResponder != nil){
-                nextResponder?.becomeFirstResponder()
-            } else {
-                textField.resignFirstResponder()
-            }
+        } else if let nextResponder = self.cardViewController.view.viewWithTag(nextTage) {
+            nextResponder.becomeFirstResponder()
+        } else {
+            textField.resignFirstResponder()
         }
     }
     
@@ -357,7 +354,7 @@ public class Openpay {
     }
     
     private func validateCharacters(textFieldToChange: UITextField) {
-        for chr in (textFieldToChange.text?.characters)! {
+        for chr in (textFieldToChange.text)! {
             if (!(chr >= "a" && chr <= "z") && !(chr >= "A" && chr <= "Z") && !(chr >= " " && chr <= " ") ) {
                 textFieldToChange.deleteBackward()
             }
@@ -440,11 +437,11 @@ public class Openpay {
             segments = [4,8,12,16]
         }
         
-        var ci: Int = 0;
-        var cp: Int = 0;
-        for i in cleanNumber.characters {
+        var ci: Int = 0
+        var cp: Int = 0
+        for i in cleanNumber {
             if( segments[0] != 0 && cp == segments[ci] ) {
-                outNumber.characters.append(separator)
+                outNumber.append(separator)
                 if(segments.count > 1) {
                     if(ci < segments.count) {
                         ci += 1
@@ -453,7 +450,7 @@ public class Openpay {
                     }
                 }
             }
-            outNumber.characters.append(i)
+            outNumber.append(i)
             cp += 1
         }
         
@@ -467,11 +464,11 @@ public class Openpay {
         let min = 5
         validateCharacters(textFieldToChange: textField)
         processCard.holderName = textField.text!
-        holderValid = ((textField.text?.characters.count)! > min && (textField.text?.characters.count)! <= max)
+        holderValid = ((textField.text?.count)! > min && (textField.text?.count)! <= max)
         textField.textColor = holderValid ? UIColor.black : UIColor.red
-        if textField.text?.characters.count == max && holderValid {
+        if textField.text?.count == max && holderValid {
             textFieldShouldReturn(textField: textField)
-        } else if (textField.text?.characters.count)! > max {
+        } else if (textField.text?.count)! > max {
             textField.deleteBackward()
         }
         checkButtonCard()
@@ -483,7 +480,7 @@ public class Openpay {
         if processCard.numberValid {
             textFieldShouldReturn(textField: textField)
         }
-        if (textField.text?.characters.count)! > max {
+        if (textField.text?.count)! > max {
             textField.deleteBackward()
         }
         let formattedNumber = formatCardNumber(cardNumber: textField.text!, type: processCard.type)
@@ -498,7 +495,7 @@ public class Openpay {
         if cvvValid {
             textField.superview?.endEditing(true)
         }
-        if (textField.text?.characters.count)! > max {
+        if (textField.text?.count)! > max {
             textField.deleteBackward()
         }
         checkButtonCard()
@@ -519,10 +516,9 @@ public class Openpay {
                 processCard.expirationYear = String(format: "%02d", (year.value-2000))
                 dateField.setTitle(String(format: "%02d / %04d", month.value, year.value), for: UIControlState.normal)
                 checkButtonCard()
-                let nextTag = picker.tag+1;
-                let nextResponder = self.cardViewController.view.viewWithTag(nextTag) as UIResponder!
-                if (nextResponder != nil) {
-                    nextResponder?.becomeFirstResponder()
+                let nextTag = picker.tag+1
+                if let nextResponder = self.cardViewController.view.viewWithTag(nextTag) {
+                    nextResponder.becomeFirstResponder()
                 } else {
                     picker.resignFirstResponder()
                 }
@@ -542,16 +538,21 @@ public class Openpay {
         if let cvvField = self.cardViewController.view.viewWithTag(indexTag.cvv.rawValue) as? SecureUITextField {
             cvvField.textColor = (processCard.securityCodeCheck == OPCard.OPCardSecurityCodeCheck.OPCardSecurityCodeCheckPassed) ? UIColor.black : UIColor.red
         }
-
+        
         let enabled = processCard.valid &&
-                      (processCard.securityCodeCheck == OPCard.OPCardSecurityCodeCheck.OPCardSecurityCodeCheckPassed) &&
-                      holderValid
+            (processCard.securityCodeCheck == OPCard.OPCardSecurityCodeCheck.OPCardSecurityCodeCheckPassed) &&
+        holderValid
         
         if let topItem = cardViewController.navigationController?.navigationBar.topItem {
             topItem.rightBarButtonItem?.isEnabled = enabled
         }
     }
     
+    deinit {
+        print("deinit: \(self)")
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardDidShow, object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+    }
 }
 
 


### PR DESCRIPTION
OpenPay SDK subscribes on `UIKeyboardDidShow`, `UIKeyboardWillHide`  notifications from `NotificationCenter` but never unsubscribes from it. 
Then, when someone hides the keyboard on another screen, this notification is launched, but if for some reason OpenPay-related view is not disposed, it crashes the app.
This pull request is adding unsubscribe in `deinit` in order to avoid infinite subscriptions that are never disposed.

Sample error below:
```
#0. Crashed: com.apple.main-thread
0  Openpay                        0x10bd946f8 $S7OpenpayAAC20keyboardWillBeHidden33_156CF1A2C97B94A39272735542C02521LL12notificationySo14NSNotificationC_tFTo + 180
1  CoreFoundation                 0x19ebfb94c __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 20
2  CoreFoundation                 0x19ebfb918 ___CFXRegistrationPost_block_invoke + 64
3  CoreFoundation                 0x19ebfae08 _CFXRegistrationPost + 392
4  CoreFoundation                 0x19ebfaab4 ___CFXNotificationPost_block_invoke + 96
5  CoreFoundation                 0x19eb72c90 -[_CFXNotificationRegistrar find:object:observer:enumerator:] + 1404
6  CoreFoundation                 0x19ebfa540 _CFXNotificationPost + 696
7  Foundation                     0x19f60bca0 -[NSNotificationCenter postNotificationName:object:userInfo:] + 68
```